### PR TITLE
Fix compatibility issue of breaking changes in PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: php
 
 php:
   - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 env:
   global:

--- a/Model/Behavior/LampagerBehavior.php
+++ b/Model/Behavior/LampagerBehavior.php
@@ -79,7 +79,7 @@ class LampagerBehavior extends ModelBehavior
          */
         extract($extra, EXTR_SKIP);
 
-        return $model->find('lampager', compact(
+        return $model->find('lampager', compact(array_intersect([
             'conditions',
             'fields',
             'order',
@@ -92,7 +92,7 @@ class LampagerBehavior extends ModelBehavior
             'inclusive',
             'seekable',
             'unseekable',
-            'cursor'
-        ));
+            'cursor',
+        ], array_keys(get_defined_vars()))));
     }
 }


### PR DESCRIPTION
Now that `compact()` emits NOTICE for undefined variables so this PR fixes it.

The support for PHP 7.0 has been dropped due to its termination of the official support.